### PR TITLE
Solve UTF-16 issue for PowerShell users

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -27,6 +27,7 @@ Then, create an empty config file to let editors and other tooling know you are 
 ```bash
 echo {}> .prettierrc.json
 ```
+> If you are using PowerShell run `echo "{}" | out-file .prettierrc.json -encoding utf8` instead. 
 
 Next, create a [.prettierignore](ignore.md) file to let the Prettier CLI and editors know which files to _not_ format. Here’s an example:
 


### PR DESCRIPTION
Following current install instructions on Powershell creates .prettierrc.json in a UTF-16 format. It results in Prettier not functioning. Since PowerShell is a popular CLI tool a solution is needed. 

This solves https://github.com/prettier/prettier/issues/8815 
